### PR TITLE
Remove photo album `entityType` conversion to `int`

### DIFF
--- a/classes/event_handler.php
+++ b/classes/event_handler.php
@@ -130,7 +130,7 @@ class PHOTO_CLASS_EventHandler
         $albumName = trim($params['name']);
         $userId = !empty($params['userId']) ? (int) $params['userId'] : null;
         $entityId = !empty($params['entityId']) ? (int) $params['entityId'] : $userId;
-        $entityType = !empty($params['entityType']) ? (int) $params['entityType'] : 'user';
+        $entityType = !empty($params['entityType']) ? $params['entityType'] : 'user';
 
         $album = $this->albumService->findEntityAlbumByName($albumName, $entityId, $entityType);
         


### PR DESCRIPTION
`entityType` field of photo album is of `string` type and should not be converted to `int`. It may lead to undefined behaviour if an album created using `photo.album_add` event.